### PR TITLE
Bookmarks displayed on toolbars appear as favicons

### DIFF
--- a/toolbars/faviconized-bookmarks.css
+++ b/toolbars/faviconized-bookmarks.css
@@ -1,0 +1,13 @@
+// When bookmarks are displayed on a toolbar, they appear as favicons. (Text is hidden)
+// Screenshot: https://s26.postimg.org/lnb9akmbd/Faviconized-bookmarks.png
+// Tested on Firefox 55, Windows 7
+
+// Hides bookmark text when they are displayed on a toolbar
+.bookmark-item > .toolbarbutton-text {
+		display: none !important;
+}
+
+// Small visual tweak so it looks exactly the same as if the bookmark really had no text
+.bookmark-item > .toolbarbutton-icon	{
+		margin-inline-end: 0px !important;
+}


### PR DESCRIPTION
When bookmarks are displayed on a toolbar, they appear as favicons. Text is hidden as per [screenshot](https://s26.postimg.org/lnb9akmbd/Faviconized-bookmarks.png).

This is a Classic Theme Restorer feature, or so I hear.